### PR TITLE
Update to use v1.0.2 of the prototype-kit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "tidy-clean": "rm -rf build"
   },
   "dependencies": {
-    "@ons/prototype-kit": "git+https://github.com/ONSdigital/prototype-kit#v1.0.1",
+    "@ons/prototype-kit": "git+https://github.com/ONSdigital/prototype-kit#v1.0.2",
     "gulp": "^4.0.2"
   }
 }


### PR DESCRIPTION
There are no changes between v1.0.1 and v1.0.2 on the prototype-kit that affect usage but for consistency depend upon the latest version.