### PR TITLE
add gulp tasks and provide documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ This project uses [gulp](https://gulpjs.com/) to automate the above commands. Th
 
 Additional gulp tasks can be added to this project's `gulpfile.js` in the usual way. Refer to the gulp documentation for information on how to do this.
 
+## Adding gulp tasks
+
+Some example tasks has been added to the gulp.js file for reference.
+
+Do the following after adding in a task:
+
+1. Go to the package.json file. Under the scripts section, Add in the build script name. for example `"build-static-files": "gulp prototype-kit:build-static-files"`
+2. In your terminal, run "yarn 'build script name'" for example "yarn build-static-files"
+
 ## Using a specific version of the design system
 
 Begin by adding a reference to the specific design system version in the `package.json` file of this repository; for example, if version 44.0.0 were required then this would look like this:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,9 +3,10 @@ import definePrototypeKitGulpTasks from '@ons/prototype-kit/defineGulpTasks.js';
 
 definePrototypeKitGulpTasks(gulp);
   
-/* You can define specific gulp tasks here. Further instructions are in the README file. */ 
+/* Define specific gulp tasks in this section. Refer to the README file for additional instructions. */ 
+/* Below are examples of tasks you can define */
 
-/* Task to build static files */
+/* Example: Task to build static files */
 // const staticFileExtensions = ['jpg', 'jpeg', 'png', 'gif', 'mp4', 'mpeg'];
 //   gulp.task('prototype-kit:build-static-files', () => {
 //   return gulp
@@ -13,7 +14,7 @@ definePrototypeKitGulpTasks(gulp);
 //     .pipe(gulp.dest('./build'));
 // });
 
-/* Task to build user-defined JS files */
+/* Example: Task to build user-defined JS files */
 //   gulp.task('prototype-kit:build-js', () => {
 //   return gulp
 //     .src('./src/**/*.js')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,3 +2,20 @@ import gulp from 'gulp';
 import definePrototypeKitGulpTasks from '@ons/prototype-kit/defineGulpTasks.js';
 
 definePrototypeKitGulpTasks(gulp);
+  
+/* You can define specific gulp tasks here. Further instructions are in the README file. */ 
+
+/* Task to build static files */
+// const staticFileExtensions = ['jpg', 'jpeg', 'png', 'gif', 'mp4', 'mpeg'];
+//   gulp.task('prototype-kit:build-static-files', () => {
+//   return gulp
+//     .src(`./src/**/*.{${staticFileExtensions.join(',')}}`)
+//     .pipe(gulp.dest('./build'));
+// });
+
+/* Task to build user-defined JS files */
+//   gulp.task('prototype-kit:build-js', () => {
+//   return gulp
+//     .src('./src/**/*.js')
+//     .pipe(gulp.dest('./build'));
+// });


### PR DESCRIPTION
Fixes [#2812](https://github.com/ONSdigital/design-system/issues/2812) and  [#2811](https://github.com/ONSdigital/design-system/issues/2811)
I added a sample gulp task for building static files as well as javascript files . I also added documentation so that users can define specific tasks based on use case