### PR TITLE
Update documentation for linking Json to Autosuggest component

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ If you need to add custom CSS to style a new component or override styling on an
 
 ### Linking JSON file to the Autosuggest component
 
- To link the JSON file to the autosuggest component locally, check the example 3 in gulpfile.js file which takes the json files stored in /src/prototypes/example/data folder
+ Follow these steps to correctly link the JSON file to the autosuggest component:
 
- When deploying the prototype, create a new public gist at https://gist.github.com/ and add the Json file using .json extension. Once you create the gist, click on 'raw' button and copy the URL into the autosuggestData param.
+1. Place the JSON file inside the `/src/prototypes/example/data/` folder.  
+
+2. Use **Example 3** in `gulpfile.js` to define a new Gulp task, `build-json`, that copies the JSON file to the `build/` folder.  
+
+3. Add `"build-json": "gulp build-json"` to the script section in `package.json`
+
+4. Run the Gulp Task using `yarn build-json`. This ensures that the JSON file is correctly placed in the build/ folder.
+
+5. When using the autosuggest component, ensure that you reference the correct path for the autosuggestData param. The path should be `data/<json-filename>`
+
+ Note-: When deploying the prototype, create a new public gist at https://gist.github.com/ and add the Json file using .json extension. Then, click on 'raw' button and copy the URL into the autosuggestData param.

--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ If you need to add custom JavaScript to your prototype, the build system will au
 ### Custom CSS
 
 If you need to add custom CSS to style a new component or override styling on an existing component you can create a `.scss` file in the directory of your prototype. Gulp will spit out a `.css` file named the same as any `.scss` file that isn't prefixed with an underscore. You can refer to the example folder to see how to include generated css in your template.
+
+### Linking JSON file to the Autosuggest component
+
+ To link the JSON file to the autosuggest component locally, check the example 3 in gulpfile.js file which takes the json files stored in /src/prototypes/example/data folder
+
+ When deploying the prototype, create a new public gist at https://gist.github.com/ and add the Json file using .json extension. Once you create the gist, click on 'raw' button and copy the URL into the autosuggestData param.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,8 +22,8 @@ definePrototypeKitGulpTasks(gulp);
 // });
 
 /* Example3: Task to link the JSON file to the autosuggest component locally */
-// gulp.task('copy-static-files', () => {
-//   return gulp.src('./src/prototypes/example/data/**/*').pipe(gulp.dest('./build'));
+// gulp.task('copy-json-files', () => {
+//   return gulp.src('./src/**/**/**/*.json').pipe(gulp.dest('./build'));
 //   });
   
-//   gulp.task('build-assets', gulp.series('copy-static-files'));
+//   gulp.task('build-json', gulp.series('copy-json-files'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ definePrototypeKitGulpTasks(gulp);
 /* Define specific gulp tasks in this section. Refer to the README file for additional instructions. */ 
 /* Below are examples of tasks you can define */
 
-/* Example: Task to build static files */
+/* Example1: Task to build static files */
 // const staticFileExtensions = ['jpg', 'jpeg', 'png', 'gif', 'mp4', 'mpeg'];
 //   gulp.task('prototype-kit:build-static-files', () => {
 //   return gulp
@@ -14,9 +14,16 @@ definePrototypeKitGulpTasks(gulp);
 //     .pipe(gulp.dest('./build'));
 // });
 
-/* Example: Task to build user-defined JS files */
+/* Example2: Task to build user-defined JS files */
 //   gulp.task('prototype-kit:build-js', () => {
 //   return gulp
 //     .src('./src/**/*.js')
 //     .pipe(gulp.dest('./build'));
 // });
+
+/* Example3: Task to link the JSON file to the autosuggest component locally */
+// gulp.task('copy-static-files', () => {
+//   return gulp.src('./src/prototypes/example/data/**/*').pipe(gulp.dest('./build'));
+//   });
+  
+//   gulp.task('build-assets', gulp.series('copy-static-files'));


### PR DESCRIPTION
### What is the context of this PR?

[ONSDESYS-114](https://jira.ons.gov.uk/browse/ONSDESYS-114)

This updates the documentation on how to link a Json to the Autosuggest component.

### How to review this PR

Check that Readme and gulpfile.js are updated.
